### PR TITLE
Fix migrations

### DIFF
--- a/migrations/versions/542bfbdef624_constrain_dependencies_to_have_no_.py
+++ b/migrations/versions/542bfbdef624_constrain_dependencies_to_have_no_.py
@@ -2,7 +2,7 @@
 (serde) to consistently store the dependency bindings.
 
 Revision ID: 542bfbdef624
-Revises: 66121a0432bc
+Revises: 99fd5e88689c
 Create Date: 2022-09-13 10:57:44.977492
 
 """
@@ -14,7 +14,7 @@ from buildingmotif.database.tables import DepsAssociation
 
 # revision identifiers, used by Alembic.
 revision = "542bfbdef624"
-down_revision = "66121a0432bc"
+down_revision = "99fd5e88689c"
 branch_labels = None
 depends_on = None
 


### PR DESCRIPTION
before
```
💚 poetry run alembic history
66121a0432bc -> 542bfbdef624 (head), Constrain dependencies to have no duplicates. Uses new JSON serialization/deserialization (serde) to consistently store the dependency bindings.
66121a0432bc -> 99fd5e88689c (head), Add description to Model
3fcdf6f2886b -> 66121a0432bc (branchpoint), add optional_args to template
ee47e252795d -> 3fcdf6f2886b, Add ShapeCollections
<base> -> ee47e252795d, init db
```
after
```
💚 poetry run alembic history                       
99fd5e88689c -> 542bfbdef624 (head), Constrain dependencies to have no duplicates. Uses new JSON serialization/deserialization
(serde) to consistently store the dependency bindings.
66121a0432bc -> 99fd5e88689c, Add description to Model
3fcdf6f2886b -> 66121a0432bc, add optional_args to template
ee47e252795d -> 3fcdf6f2886b, Add ShapeCollections
<base> -> ee47e252795d, init db
```

We should write a github action that ensures the migrations only have one head