### PR TITLE
update docs for in/ex-cluded libraries

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,23 +2,29 @@
 
 [![codecov](https://codecov.io/gh/NREL/BuildingMOTIF/branch/main/graph/badge.svg?token=HAFSYH45NX)](https://codecov.io/gh/NREL/BuildingMOTIF) 
 [![Jupyter Book Badge](https://jupyterbook.org/badge.svg)](https://nrel.github.io/BuildingMOTIF/)
+![PyPI](https://img.shields.io/pypi/v/buildingmotif)
+![PyPI - Downloads](https://img.shields.io/pypi/dm/buildingmotif)
 
 > *Enabling the enabling technology of semantic interoperability.*
 
-Semantic Interoperability in buildings through standardized semantic metadata is crucial to unlocking the value of the abundant and diverse networked data in buildings, avoiding subsequent data incompatibility/interoperability issues, and paving the way for advanced building technologies like Automated Fault Detection and Diagnostics (AFDD), real-time energy optimization, other energy management information systems ([EMIS](https://www.energy.gov/eere/femp/what-are-energy-management-information-systems)), improved HVAC controls, and grid-interactive energy efficient building ([GEB](https://www.energy.gov/eere/buildings/grid-interactive-efficient-buildings)) technologies, all of which are needed to fully de-carbonize buildings. Utilizing the capabilities of [Semantic Web](https://www.w3.org/standards/semanticweb/), it is possible to standardize building metadata in structured, expressive, and machine-readable ways, but at the same time it is very important to make it easier to implement for field practitioners without advanced knowledge in computer science. 
+Semantic Interoperability in buildings through standardized semantic metadata is crucial in unlocking the value of the abundant and diverse networked data in buildings, avoiding subsequent data incompatibility/interoperability issues, and paving the way for advanced building technologies like Fault Detection and Diagnostics (FDD), real-time energy optimization, other energy management information systems ([EMIS](https://www.energy.gov/eere/femp/what-are-energy-management-information-systems)), improved HVAC controls, and grid-integrated energy efficient building ([GEB](https://www.energy.gov/eere/buildings/grid-interactive-efficient-buildings)) technologies, all of which are needed to fully de-carbonize buildings.
 
-***Building Metadata OnTology Interoperability Framework (BuildingMOTIF)*** bridges that gap between theory and practice, by offering a toolset for building metadata creation, storage, visualization, and validation. It is offered in the form of an SDK with easy-to-use APIs that abstract the underlying complexities of [RDF](https://www.w3.org/RDF/) graphs, database management, [SHACL](https://www.w3.org/TR/shacl/) validation, and interoperability between different metadata schemas/ontologies. It also supports connectors for easier integration with existing metadata sources (e.g., Building Automation System data, design models, existing metadata models, etc.), which are available at different phases of the building life-cycle.
+Utilizing the capabilities of [Semantic Web](https://www.w3.org/standards/semanticweb/), it is possible to standardize building metadata in structured, expressive, and machine-readable way, but at the same time it is very important to make it easier to implement for field practitioners without advanced knowledge in computer science. ***Building Metadata OnTology Interoperability Framework (BuildingMOTIF)*** bridges that gap between theory and practice, by offering a toolset for building metadata creation, storage, visualization, and validation. It is offered in the form of a SDK with easy-to-use APIs, which abstract the underlying complexities of [RDF](https://www.w3.org/RDF/) graphs, database management, [SHACL](https://www.w3.org/TR/shacl/) validation, and interoperability between different metadata schemas/ontologies. It also supports connectors for easier integration with existing metadata sources (e.g., Building Automation System data, design models, existing metadata models, etc.) which are available at different phases of the building life-cycle.
 
-The objectives of the ***BuildingMOTIF*** toolset are the following:
-1. lower costs, reduce installation time, and improve delivered quality of building controls and services for building owners and occupants
-2. enable a simpler and more easily verifiable procurement process for products and services for building managers
-3. open new business opportunities for service providers, by removing knowledge barriers for parties implementing building controls and services
+The objectives of the ***BuildingMOTIF*** toolset are to (1) lower costs, reduce installation time, and improve delivered quality of building controls and services for building owners and occupants, (2) enable a simpler and more easily verifiable procurement process for products and services for building managers, and (3) open new business opportunities for service providers, by removing knowledge barriers for parties implementing building controls and services.
 
-Currently, ***BuildingMOTIF*** is planned to support the [Brick Schema](https://brickschema.org/), [Project Haystack](https://project-haystack.org/), and the proposed [ASHRAE Standard 223P](https://www.ashrae.org/about/news/2018/ashrae-s-bacnet-committee-project-haystack-and-brick-schema-collaborating-to-provide-unified-data-semantic-modeling-solution), and to offer both a UI and underlying SDK with tutorials and reference documentation to be useful for different levels of expertise of users for maximum adoption.
+Currently, ***BuildingMOTIF*** is planned to support [Brick](https://brickschema.org/) Schema, [Project Haystack](https://project-haystack.org/), and the upcoming [ASHRAE 223P](https://www.ashrae.org/about/news/2018/ashrae-s-bacnet-committee-project-haystack-and-brick-schema-collaborating-to-provide-unified-data-semantic-modeling-solution) standard, and to offer both UI and underlying SDK with tutorials and reference documentation to be useful for different levels of expertise of users for maximum adoption.
 
 # Documentation
 
-The documentation uses [Diataxis](https://diataxis.fr/) as a framework for its structure, which is organized into the following sections.
+The documentation uses Diataxis[^1] as a framework for its structure, which is organized into the following sections.
+
+[^1]: https://diataxis.fr/
+
+## Reference
+
+- [Developer Documentation](https://nrel.github.io/BuildingMOTIF/reference/developer_documentation.html)
+- [Code Documentation](https://nrel.github.io/BuildingMOTIF/reference/apidoc/index.html)
 
 ## Tutorials
 
@@ -30,11 +36,6 @@ The documentation uses [Diataxis](https://diataxis.fr/) as a framework for its s
 ## How-to Guides
 
 🏗️ under construction
-
-## Reference
-
-- [Code Documentation](https://nrel.github.io/BuildingMOTIF/reference/apidoc/index.html)
-- [Developer Documentation](https://nrel.github.io/BuildingMOTIF/reference/developer_documentation.html)
 
 ## Explanation
 

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ The documentation uses Diataxis[^1] as a framework for its structure, which is o
 - [Model Correction](https://nrel.github.io/BuildingMOTIF/tutorials/model_correction.html)
 - [Template Writing](https://nrel.github.io/BuildingMOTIF/tutorials/template_writing.html)
 
-## How-to Guides
+## Guides
 
 🏗️ under construction
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -2,23 +2,29 @@
 
 [![codecov](https://codecov.io/gh/NREL/BuildingMOTIF/branch/main/graph/badge.svg?token=HAFSYH45NX)](https://codecov.io/gh/NREL/BuildingMOTIF) 
 [![Jupyter Book Badge](https://jupyterbook.org/badge.svg)](https://nrel.github.io/BuildingMOTIF/)
+![PyPI](https://img.shields.io/pypi/v/buildingmotif)
+![PyPI - Downloads](https://img.shields.io/pypi/dm/buildingmotif)
 
 > *Enabling the enabling technology of semantic interoperability.*
 
-Semantic Interoperability in buildings through standardized semantic metadata is crucial to unlocking the value of the abundant and diverse networked data in buildings, avoiding subsequent data incompatibility/interoperability issues, and paving the way for advanced building technologies like Automated Fault Detection and Diagnostics (AFDD), real-time energy optimization, other energy management information systems ([EMIS](https://www.energy.gov/eere/femp/what-are-energy-management-information-systems)), improved HVAC controls, and grid-interactive energy efficient building ([GEB](https://www.energy.gov/eere/buildings/grid-interactive-efficient-buildings)) technologies, all of which are needed to fully de-carbonize buildings. Utilizing the capabilities of [Semantic Web](https://www.w3.org/standards/semanticweb/), it is possible to standardize building metadata in structured, expressive, and machine-readable ways, but at the same time it is very important to make it easier to implement for field practitioners without advanced knowledge in computer science. 
+Semantic Interoperability in buildings through standardized semantic metadata is crucial in unlocking the value of the abundant and diverse networked data in buildings, avoiding subsequent data incompatibility/interoperability issues, and paving the way for advanced building technologies like Fault Detection and Diagnostics (FDD), real-time energy optimization, other energy management information systems ([EMIS](https://www.energy.gov/eere/femp/what-are-energy-management-information-systems)), improved HVAC controls, and grid-integrated energy efficient building ([GEB](https://www.energy.gov/eere/buildings/grid-interactive-efficient-buildings)) technologies, all of which are needed to fully de-carbonize buildings.
 
-***Building Metadata OnTology Interoperability Framework (BuildingMOTIF)*** bridges that gap between theory and practice, by offering a toolset for building metadata creation, storage, visualization, and validation. It is offered in the form of an SDK with easy-to-use APIs that abstract the underlying complexities of [RDF](https://www.w3.org/RDF/) graphs, database management, [SHACL](https://www.w3.org/TR/shacl/) validation, and interoperability between different metadata schemas/ontologies. It also supports connectors for easier integration with existing metadata sources (e.g., Building Automation System data, design models, existing metadata models, etc.), which are available at different phases of the building life-cycle.
+Utilizing the capabilities of [Semantic Web](https://www.w3.org/standards/semanticweb/), it is possible to standardize building metadata in structured, expressive, and machine-readable way, but at the same time it is very important to make it easier to implement for field practitioners without advanced knowledge in computer science. ***Building Metadata OnTology Interoperability Framework (BuildingMOTIF)*** bridges that gap between theory and practice, by offering a toolset for building metadata creation, storage, visualization, and validation. It is offered in the form of a SDK with easy-to-use APIs, which abstract the underlying complexities of [RDF](https://www.w3.org/RDF/) graphs, database management, [SHACL](https://www.w3.org/TR/shacl/) validation, and interoperability between different metadata schemas/ontologies. It also supports connectors for easier integration with existing metadata sources (e.g., Building Automation System data, design models, existing metadata models, etc.) which are available at different phases of the building life-cycle.
 
-The objectives of the ***BuildingMOTIF*** toolset are the following:
-1. lower costs, reduce installation time, and improve delivered quality of building controls and services for building owners and occupants
-2. enable a simpler and more easily verifiable procurement process for products and services for building managers
-3. open new business opportunities for service providers, by removing knowledge barriers for parties implementing building controls and services
+The objectives of the ***BuildingMOTIF*** toolset are to (1) lower costs, reduce installation time, and improve delivered quality of building controls and services for building owners and occupants, (2) enable a simpler and more easily verifiable procurement process for products and services for building managers, and (3) open new business opportunities for service providers, by removing knowledge barriers for parties implementing building controls and services.
 
-Currently, ***BuildingMOTIF*** is planned to support the [Brick Schema](https://brickschema.org/), [Project Haystack](https://project-haystack.org/), and the proposed [ASHRAE Standard 223P](https://www.ashrae.org/about/news/2018/ashrae-s-bacnet-committee-project-haystack-and-brick-schema-collaborating-to-provide-unified-data-semantic-modeling-solution), and to offer both a UI and underlying SDK with tutorials and reference documentation to be useful for different levels of expertise of users for maximum adoption.
+Currently, ***BuildingMOTIF*** is planned to support [Brick](https://brickschema.org/) Schema, [Project Haystack](https://project-haystack.org/), and the upcoming [ASHRAE 223P](https://www.ashrae.org/about/news/2018/ashrae-s-bacnet-committee-project-haystack-and-brick-schema-collaborating-to-provide-unified-data-semantic-modeling-solution) standard, and to offer both UI and underlying SDK with tutorials and reference documentation to be useful for different levels of expertise of users for maximum adoption.
 
 # Documentation
 
-The documentation uses [Diataxis](https://diataxis.fr/) as a framework for its structure, which is organized into the following sections.
+The documentation uses Diataxis[^1] as a framework for its structure, which is organized into the following sections.
+
+[^1]: https://diataxis.fr/
+
+## Reference
+
+- [Developer Documentation](https://nrel.github.io/BuildingMOTIF/reference/developer_documentation.html)
+- [Code Documentation](https://nrel.github.io/BuildingMOTIF/reference/apidoc/index.html)
 
 ## Tutorials
 
@@ -30,11 +36,6 @@ The documentation uses [Diataxis](https://diataxis.fr/) as a framework for its s
 ## How-to Guides
 
 🏗️ under construction
-
-## Reference
-
-- [Code Documentation](https://nrel.github.io/BuildingMOTIF/reference/apidoc/index.html)
-- [Developer Documentation](https://nrel.github.io/BuildingMOTIF/reference/developer_documentation.html)
 
 ## Explanation
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -33,7 +33,7 @@ The documentation uses Diataxis[^1] as a framework for its structure, which is o
 - [Model Correction](https://nrel.github.io/BuildingMOTIF/tutorials/model_correction.html)
 - [Template Writing](https://nrel.github.io/BuildingMOTIF/tutorials/template_writing.html)
 
-## How-to Guides
+## Guides
 
 🏗️ under construction
 

--- a/docs/_toc.yml
+++ b/docs/_toc.yml
@@ -15,12 +15,12 @@ parts:
   - file: tutorials/model_validation.md
   - file: tutorials/model_correction.md
   - file: tutorials/template_writing.ipynb
-# - caption: How-to guides
+# - caption: Guides
 #   chapters:
-#   - file: how_to_guides/todo.md
+#   - file: guides/TODO.md
 # - caption: Explaination
 #   chapters:
-#   - file: explaination/todo.md
+#   - file: explaination/TODO.md
 - caption: Appendix
   chapters:
   - file: bibliography.md

--- a/docs/_toc.yml
+++ b/docs/_toc.yml
@@ -5,6 +5,10 @@
 format: jb-book
 root: README
 parts:
+- caption: Reference
+  chapters:
+  - file: reference/developer_documentation.md
+  - file: reference/apidoc/index.rst
 - caption: Tutorials
   chapters:
   - file: tutorials/model_creation.md
@@ -14,10 +18,6 @@ parts:
 # - caption: How-to guides
 #   chapters:
 #   - file: how_to_guides/todo.md
-- caption: Reference
-  chapters:
-  - file: reference/apidoc/index.rst
-  - file: reference/developer_documentation.md
 # - caption: Explaination
 #   chapters:
 #   - file: explaination/todo.md

--- a/docs/tutorials/model_correction.md
+++ b/docs/tutorials/model_correction.md
@@ -24,6 +24,11 @@ The purpose of this tutorial is to learn how to fix a model that fails validatio
 
 Like the previous tutorial, we'll create an in-memory BuildingMOTIF instance, load the model, and load some libraries. We'll also load the manifest from the previous tutorial.
 
+```{margin}
+```{warning}
+Currently, libraries in `../../buildingmotif/libraries/` are *included* and libraries in `../../libraries/` are *excluded* from the [BuildingMOTIF Python package](https://pypi.org/project/buildingmotif/) (available by cloning, downloading, or forking the repository). See https://github.com/NREL/BuildingMOTIF/issues/133. 
+```
+
 ```{code-cell}
 from rdflib import Namespace
 from buildingmotif import BuildingMOTIF
@@ -39,13 +44,15 @@ BLDG = Namespace('urn:bldg/')
 # create the building model
 model = Model.create(BLDG, description="This is a test model for a simple building")
 
-# load tutorial 1 model
+# load tutorial 2 model and manifest
 model.graph.parse("tutorial2_model.ttl", format="ttl")
-
-# load in some libraries
-brick = Library.load(ontology_graph="../../libraries/brick/Brick-subset.ttl")
-constraints = Library.load(ontology_graph="../../buildingmotif/resources/constraints.ttl")
 manifest = Library.load(ontology_graph="tutorial2_manifest.ttl")
+
+# load libraries included with the python package
+constraints = Library.load(ontology_graph="../../buildingmotif/libraries/constraints/constraints.ttl")
+
+# load libraries excluded from the python package (available from the repository)
+brick = Library.load(ontology_graph="../../libraries/brick/Brick-subset.ttl")
 g36 = Library.load(directory="../../libraries/ashrae/guideline36")
 ```
 

--- a/docs/tutorials/model_creation.md
+++ b/docs/tutorials/model_creation.md
@@ -77,6 +77,11 @@ The `model.graph` object is just the RDFLib Graph[^4] that stores the model. You
 
 Before we can add semantic metadata to the model, we need to import some `Libraries`. We import libraries by calling `Library.load` in BuildingMOTIF. Libraries can be loaded from directories containing `.yml` and `.ttl` files (for Templates and Shapes, respectively), or from ontology files directly. The code below contains an example of importing the `brick` library, which is simply the Brick ontology. This allows BuildingMOTIF to take advantage of the classes and relationships defined by Brick when validating the model. Loading in these definitions also allows other libraries to refer to Brick definitions. You can also ask a library for the names of the templates it defines, which we'll limit to the first ten below.
 
+```{margin}
+```{warning}
+Currently, libraries in `../../buildingmotif/libraries/` are *included* and libraries in `../../libraries/` are *excluded* from the [BuildingMOTIF Python package](https://pypi.org/project/buildingmotif/) (available by cloning, downloading, or forking the repository). See https://github.com/NREL/BuildingMOTIF/issues/133. 
+```
+
 ```{code-cell}
 # load a library
 from buildingmotif.dataclasses import Library

--- a/docs/tutorials/model_validation.md
+++ b/docs/tutorials/model_validation.md
@@ -42,6 +42,11 @@ Validating a model is the process of ensuring that the model is both *correct* (
 
 We create an in-memory BuildingMOTIF instance, load the model from the previous tutorial, and load some libraries to create the manifest with. The `constraints.ttl` library we load is a special library with some custom constraints defined that are helpful for writing manifests.
 
+```{margin}
+```{warning}
+Currently, libraries in `../../buildingmotif/libraries/` are *included* and libraries in `../../libraries/` are *excluded* from the [BuildingMOTIF Python package](https://pypi.org/project/buildingmotif/) (available by cloning, downloading, or forking the repository). See https://github.com/NREL/BuildingMOTIF/issues/133. 
+```
+
 ```{code-cell}
 from rdflib import Namespace
 from buildingmotif import BuildingMOTIF
@@ -60,9 +65,11 @@ model = Model.create(BLDG, description="This is a test model for a simple buildi
 # load tutorial 1 model
 model.graph.parse("tutorial1_model.ttl", format="ttl")
 
-# load in some libraries
+# load libraries included with the python package
+constraints = Library.load(ontology_graph="../../buildingmotif/libraries/constraints/constraints.ttl")
+
+# load libraries excluded from the python package (available from the repository)
 brick = Library.load(ontology_graph="../../libraries/brick/Brick-subset.ttl")
-constraints = Library.load(ontology_graph="../../buildingmotif/resources/constraints.ttl")
 g36 = Library.load(directory="../../libraries/ashrae/guideline36")
 ```
 


### PR DESCRIPTION
1. Update tutorials with warnings for libraries loaded from _outside_ the Python package until #133 is addressed. 
2. Adds PyPi badges to the READMEs and moves the References section up to the first section for future Getting Started/Installation, CONTRIBUTING, SUPPORT, etc.