### PR TITLE
disable repo-visualizer

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -24,13 +24,13 @@ jobs:
           ref: ${{github.event.pull_request.head.ref}}
       - name: setup-python
         uses: actions/setup-python@v3
-      # update repo visualization for docs
-      - name: repo-visualizer
-        uses: githubocto/repo-visualizer@0.8.2
-        with:
-          output_file: docs/reference/apidoc/code_visualization.svg
-          excluded_paths: ".github"
-          commit_message: "repo-visualizer [skip actions]"
+      # # update repo visualization for docs
+      # - name: repo-visualizer
+      #   uses: githubocto/repo-visualizer@0.8.2
+      #   with:
+      #     output_file: docs/reference/apidoc/code_visualization.svg
+      #     excluded_paths: ".github"
+      #     commit_message: "repo-visualizer [skip actions]"
       # install project, which is required for autodoc of code
       - name: install buildingmotif
         run: pip install .

--- a/docs/reference/apidoc/index.rst
+++ b/docs/reference/apidoc/index.rst
@@ -7,7 +7,7 @@ Code Documentation
 
    buildingmotif
 
-Code Visualization
-==================
+.. Code Visualization
+.. ==================
 
-.. image:: code_visualization.svg
+.. .. image:: code_visualization.svg


### PR DESCRIPTION
Close #234. 

>example: https://github.com/NREL/BuildingMOTIF/actions/runs/4494399949/jobs/7906838362
>We either have to 1. override the branch protections somehow or 2. skip this step on protected branches.

Suggest revisiting later. See `https://github.com/githubocto/repo-visualizer/issues/29`.