### PR TITLE
Fix migrations in postgres

### DIFF
--- a/migrations/versions/542bfbdef624_constrain_dependencies_to_have_no_.py
+++ b/migrations/versions/542bfbdef624_constrain_dependencies_to_have_no_.py
@@ -23,9 +23,7 @@ def upgrade():
     # add NULLABLE 'id' column
     with op.batch_alter_table("deps_association_table", schema=None) as batch_op:
         batch_op.drop_constraint("deps_association_table_pkey", type_="primary")
-        batch_op.add_column(
-            sa.Column("id", sa.Integer(), nullable=True, primary_key=True)
-        )
+        batch_op.add_column(sa.Column("id", sa.Integer(), primary_key=True))
 
         batch_op.alter_column(
             "dependant_id", existing_type=sa.INTEGER(), nullable=False

--- a/migrations/versions/542bfbdef624_constrain_dependencies_to_have_no_.py
+++ b/migrations/versions/542bfbdef624_constrain_dependencies_to_have_no_.py
@@ -22,15 +22,9 @@ depends_on = None
 def upgrade():
     # add NULLABLE 'id' column
     with op.batch_alter_table("deps_association_table", schema=None) as batch_op:
-        batch_op.add_column(sa.Column("id", sa.Integer(), nullable=True))
         batch_op.drop_constraint("deps_association_table_pkey", type_="primary")
-        batch_op.create_primary_key("deps_association_pk", columns=["id"])
-        batch_op.alter_column(
-            existing_type=sa.INTEGER(),
-            column_name="id",
-            autoincrement=True,
-            existing_autoincrement=True,
-            nullable=False,
+        batch_op.add_column(
+            sa.Column("id", sa.Integer(), nullable=True, primary_key=True)
         )
 
         batch_op.alter_column(

--- a/tests/integration/fixtures/pgtest/docker-compose.yml
+++ b/tests/integration/fixtures/pgtest/docker-compose.yml
@@ -1,0 +1,50 @@
+version: "3.9"
+services:
+  db:
+    container_name: buildingmotif-db
+    image: postgres
+    environment:
+      - "POSTGRES_PASSWORD=password"
+      - "POSTGRES_USER=bmotif_pgtest"
+      - "POSTGRES_DB=bmotif_pgtest"
+    ports:
+      - target: 5432
+        published: 5432
+        protocol: tcp
+        mode: host
+    healthcheck:
+      test: ["CMD", "pg_isready", "-d", "postgresql://bmotif_pgtest:password@db:5432/bmotif_pgtest"]
+      interval: 10s
+      timeout: 30s
+      retries: 5
+      start_period: 5s
+
+  api:
+    container_name: buildingmotif-api
+    environment:
+      - "DB_URI=postgresql://bmotif_pgtest:password@db:5432/bmotif_pgtest"
+    depends_on: # require that the db is up and listening
+      db:
+        condition: service_healthy
+    build:
+      context: ../../../../.
+      dockerfile: buildingmotif/api/Dockerfile
+    image: buildingmotif-api:latest
+    ports:
+      - target: 5000
+        published: 5000
+        protocol: tcp
+        mode: host 
+
+  app:
+    container_name: buildingmotif-app
+    depends_on: # require that the api server has started
+      - api
+    build: ../../../../buildingmotif-app
+    image: buildingmotif-app:latest
+    ports:
+      - target: 4200
+        published: 4200
+        protocol: tcp
+        mode: host
+

--- a/tests/integration/test_docker_compose_postgres.py
+++ b/tests/integration/test_docker_compose_postgres.py
@@ -1,0 +1,53 @@
+import shlex
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from buildingmotif import BuildingMOTIF
+from buildingmotif.dataclasses import Library
+
+# path to libraries
+libraries_path = Path(__file__).parent.parent.parent / Path("libraries")
+# path to docker compose file (in root of repo)
+docker_compose_path = Path(__file__).parent / Path("fixtures") / Path("pgtest")
+# clean up docker compose
+docker_compose_clean = shlex.split("docker compose rm -fsv")
+# command to start docker compose
+docker_compose_start = shlex.split("docker compose up -d --build")
+# command to stop docker compose
+docker_compose_stop = shlex.split("docker compose down")
+
+
+@pytest.fixture()
+def docker_compose_setup():
+    subprocess.run(docker_compose_clean, cwd=docker_compose_path)
+    subprocess.run(docker_compose_start, cwd=docker_compose_path)
+    yield
+    subprocess.run(docker_compose_stop, cwd=docker_compose_path)
+
+
+@pytest.fixture
+def bm_pg():
+    """
+    BuildingMotif instance for tests involving dataclasses and API calls
+    Uses Postgres connection defined in the .env file!
+    """
+    db_uri = "postgresql://bmotif_pgtest:password@localhost:5432/bmotif_pgtest"
+    bm = BuildingMOTIF(db_uri)
+    # don't need to add tables to db; this is already done for us by the container
+
+    yield bm
+    bm.close()
+    # clean up the singleton so that tables are re-created correctly later
+    BuildingMOTIF.clean()
+
+
+@pytest.mark.integration
+def test_load_libraries(docker_compose_setup, bm_pg):
+    """
+    Tests that libraries load correctly into BuildingMOTIF
+    """
+    Library.load(ontology_graph=str(libraries_path / "brick" / "Brick-full.ttl"))
+    Library.load(directory=str(libraries_path / "ashrae" / "guideline36"))
+    bm_pg.session.commit()


### PR DESCRIPTION
In the `542bfbdef624_constrain_dependencies_to_have_no_.py` migration, we set `autoincrement` and `primary key` properties for the `deps_association_table.id` field. These *should* result in autoincrementing primary key behavior in all databases, but due to the way that we add/remove the constraints, the autoincrementing behavior does not get realized in a postgres database. This PR adjusts the migration (*I believe this is correct but have not tested it on existing databases*) and adds an integration test invoking the docker compose setup and inserting libraries into a migrated database instance