### PR TITLE
Fix nondeterministic test failure 

### DIFF
--- a/buildingmotif/dataclasses/validation.py
+++ b/buildingmotif/dataclasses/validation.py
@@ -60,7 +60,10 @@ class GraphDiff:
         possible_uris: Set[Node] = set(self.validation_result.subjects())
         objects: Set[Node] = set(self.validation_result.objects())
         sub_not_obj = possible_uris - objects
-        assert len(sub_not_obj) == 1
+        if len(sub_not_obj) != 1:
+            raise Exception(
+                "Validation result has more than one 'root' node, which should not happen. Please raise an issue on https://github.com/NREL/BuildingMOTIF"
+            )
         return sub_not_obj.pop()
 
     @cached_property

--- a/buildingmotif/dataclasses/validation.py
+++ b/buildingmotif/dataclasses/validation.py
@@ -51,8 +51,17 @@ class GraphDiff:
     @cached_property
     def _result_uri(self) -> Node:
         """Return the 'name' of the ValidationReport to make failed_shape/failed_component
-        easier to express"""
-        return next(self.validation_result.subjects())
+        easier to express. We compute this by taking advantage of the fact that the validation
+        result graph is actually a tree with a single root. We can find the root by finding
+        all URIs which appear as subjects in the validation_result graph that do *not* appear
+        as objects; this should  be exactly one URI which is the 'root' of the validation result
+        graph
+        """
+        possible_uris: Set[Node] = set(self.validation_result.subjects())
+        objects: Set[Node] = set(self.validation_result.objects())
+        sub_not_obj = possible_uris - objects
+        assert len(sub_not_obj) == 1
+        return sub_not_obj.pop()
 
     @cached_property
     def failed_shape(self) -> Optional[URIRef]:

--- a/tests/unit/dataclasses/test_model.py
+++ b/tests/unit/dataclasses/test_model.py
@@ -105,7 +105,10 @@ def test_validate_model_with_failure(bm: BuildingMOTIF):
     assert not ctx.valid
     assert len(ctx.diffset) == 1
     diff = ctx.diffset.pop()
-    assert isinstance(diff.failed_shape, BNode)
+    assert isinstance(diff.failed_shape, BNode), (
+        diff.failed_shape,
+        type(diff.failed_shape),
+    )
     assert diff.failed_component == SH.MinCountConstraintComponent
 
     model.add_triples((bindings["name"], RDFS.label, Literal("hvac zone 1")))


### PR DESCRIPTION
We need to correctly calculate the validation result graph root node -- the test would occasionally fail if it found a different subject than the one that was intended. This is now addressed in this PR. Sorry for breaking the build!