### PR TITLE
Adding/fixing template-to-shape functionality

### DIFF
--- a/buildingmotif/dataclasses/model.py
+++ b/buildingmotif/dataclasses/model.py
@@ -3,24 +3,15 @@ from typing import TYPE_CHECKING, Dict, List, Optional
 
 import pyshacl
 import rdflib
-import rfc3987
 
 from buildingmotif import get_building_motif
 from buildingmotif.dataclasses.shape_collection import ShapeCollection
 from buildingmotif.dataclasses.validation import ValidationContext
 from buildingmotif.namespaces import A
-from buildingmotif.utils import Triple, copy_graph, rewrite_shape_graph
+from buildingmotif.utils import Triple, copy_graph, rewrite_shape_graph, validate_uri
 
 if TYPE_CHECKING:
     from buildingmotif import BuildingMOTIF
-
-
-def _validate_uri(uri: str):
-    parsed = rfc3987.parse(uri)
-    if not parsed["scheme"]:
-        raise ValueError(
-            f"{uri} does not look like a valid URI, trying to serialize this will break."
-        )
 
 
 @dataclass
@@ -47,7 +38,7 @@ class Model:
         """
         bm = get_building_motif()
 
-        _validate_uri(name)
+        validate_uri(name)
         db_model = bm.table_connection.create_db_model(name, description)
 
         g = rdflib.Graph()

--- a/buildingmotif/dataclasses/template.py
+++ b/buildingmotif/dataclasses/template.py
@@ -12,6 +12,7 @@ from buildingmotif import get_building_motif
 from buildingmotif.dataclasses.model import Model
 from buildingmotif.namespaces import bind_prefixes
 from buildingmotif.template_matcher import Mapping, TemplateMatcher
+from buildingmotif.template_to_shape import template_to_nodeshape
 from buildingmotif.utils import (
     PARAM,
     combine_graphs,
@@ -439,6 +440,17 @@ class Template:
         matcher = TemplateMatcher(model.graph, self, ontology)
         for mapping, sg in matcher.building_mapping_subgraphs_iter():
             yield mapping, sg, matcher.remaining_template(mapping)
+
+    def to_nodeshape(self) -> rdflib.Graph:
+        """
+        Interprets the template body as a SHACL shape and returns the SHACL
+        shape in its own graph. See buildingmotif.template_to_shape.template_to_nodeshape
+        for the specific translation rules and implementation.
+
+        :return: a graph containing the NodeShape
+        :rtype: rdflib.Graph
+        """
+        return template_to_nodeshape(self)
 
 
 @dataclass

--- a/buildingmotif/template_to_shape.py
+++ b/buildingmotif/template_to_shape.py
@@ -1,0 +1,287 @@
+from collections import defaultdict
+from copy import copy
+from dataclasses import dataclass, field
+from itertools import chain
+from typing import TYPE_CHECKING, Dict, List, Optional, Tuple
+
+from rdflib import BNode, Graph, Literal, URIRef
+from rdflib.term import Node
+
+from buildingmotif.namespaces import PARAM, RDF, SH, bind_prefixes
+from buildingmotif.utils import copy_graph, validate_uri
+
+if TYPE_CHECKING:
+    from buildingmotif.dataclasses import Template
+
+
+def _add_property_shape(
+    graph: Graph,
+    name: Node,
+    constraint: Optional[Node],
+    path: Node,
+    value: Optional[Node],
+    exact_count: int = 1,
+):
+    pshape = BNode()
+    graph.add((name, SH.property, pshape))
+    graph.add((pshape, SH.path, path))
+    if constraint is not None and value is not None:
+        graph.add((pshape, constraint, value))
+    graph.add((pshape, SH["minCount"], Literal(exact_count)))
+    if exact_count > 0:
+        graph.add((pshape, SH["maxCount"], Literal(exact_count)))
+
+
+def _add_qualified_property_shape(
+    graph: Graph,
+    name: Node,
+    constraint: Node,
+    path: Node,
+    value: Node,
+    exact_count: int = 1,
+):
+    pshape = BNode()
+    graph.add((name, SH.property, pshape))
+    graph.add((pshape, SH.path, path))
+    qvc = BNode()
+    graph.add((pshape, SH["qualifiedValueShape"], qvc))
+    graph.add((qvc, constraint, value))
+    graph.add((pshape, SH["qualifiedMinCount"], Literal(exact_count)))
+    if exact_count > 0:
+        graph.add((pshape, SH["qualifiedMaxCount"], Literal(exact_count)))
+
+
+@dataclass
+class _OptNodeList:
+    required: List[Node] = field(default_factory=list)
+    optional: List[Node] = field(default_factory=list)
+
+    def __len__(self) -> int:
+        return len(self.required) + len(self.optional)
+
+    @property
+    def first(self) -> Tuple[Node, bool]:
+        if self.required:
+            return (self.required[0], True)
+        return (self.optional[0], False)
+
+    def __iter__(self):
+        return chain.from_iterable(
+            [
+                zip(self.required, [True] * len(self.required)),
+                zip(self.optional, [False] * len(self.optional)),
+            ]
+        )
+
+
+@dataclass
+class _TemplateIndex:
+    template: "Template"
+    param_types: Dict[Node, List[Node]]
+    prop_types: Dict[Node, _OptNodeList]
+    prop_values: Dict[Node, List[Node]]
+    prop_shapes: Dict[Node, _OptNodeList]
+    prop_unspecific: _OptNodeList
+    target: URIRef
+
+    @property
+    def target_type(self):
+        return self.param_types[self.target][0]
+
+    def add_to_shape(self, shape: Graph):
+        """
+        Adds this template index in its shape form
+        into the provided graph
+        """
+        self._add_prop_types_to_shape(shape)
+        self._add_prop_shapes_to_shape(shape)
+        self._add_prop_values_to_shape(shape)
+        self._add_unspecific_props_to_shape(shape)
+
+    def _add_prop_types_to_shape(self, shape: Graph):
+        """
+        Adds the prop_types index to the graph containing the shape
+        """
+        for prop, ptypes in self.prop_types.items():
+            if len(ptypes) == 1:
+                ptype, required = ptypes.first
+                mincount = 1 if required else 0
+                _add_property_shape(
+                    shape, PARAM[self.template.name], SH["class"], prop, ptype, mincount
+                )
+            else:
+                for ptype, required in ptypes:
+                    mincount = 1 if required else 0
+                    _add_qualified_property_shape(
+                        shape,
+                        PARAM[self.template.name],
+                        SH["class"],
+                        prop,
+                        ptype,
+                        mincount,
+                    )
+
+    def _add_prop_shapes_to_shape(self, shape: Graph):
+        """
+        Adds the prop_shapes index to the graph containing the shape
+        """
+        for prop, ptypes in self.prop_shapes.items():
+            if len(ptypes) == 1:
+                ptype, required = ptypes.first
+                mincount = 1 if required else 0
+                _add_property_shape(
+                    shape, PARAM[self.template.name], SH["node"], prop, ptype, mincount
+                )
+            else:
+                for ptype, required in ptypes:
+                    mincount = 1 if required else 0
+                    _add_qualified_property_shape(
+                        shape,
+                        PARAM[self.template.name],
+                        SH["node"],
+                        prop,
+                        ptype,
+                        mincount,
+                    )
+
+    def _add_prop_values_to_shape(self, shape: Graph):
+        """
+        Adds the prop_values index to the graph containing the shape
+        """
+        for prop, values in self.prop_values.items():
+            if len(values) == 1:
+                _add_property_shape(
+                    shape, PARAM[self.template.name], SH.hasValue, prop, values[0]
+                )
+            else:  # more than one ptype
+                for value in values:
+                    _add_qualified_property_shape(
+                        shape, PARAM[self.template.name], SH.hasValue, prop, value
+                    )
+
+    def _add_unspecific_props_to_shape(self, shape: Graph):
+        for prop in self.prop_unspecific:
+            _add_property_shape(shape, PARAM[self.template.name], None, prop, None)
+
+
+def _prep_shape_graph() -> Graph:
+    shape = Graph()
+    bind_prefixes(shape)
+    shape.bind("p", PARAM)
+    return shape
+
+
+def _index_properties(templ: "Template") -> _TemplateIndex:
+    templ_graph = copy_graph(templ.body)
+
+    target = PARAM["name"]
+
+    # store the classes for each parameter
+    param_types: Dict[Node, List[Node]] = defaultdict(list)
+    for (param, ptype) in templ_graph.subject_objects(RDF.type):
+        param_types[param].append(ptype)
+
+    # store the properties and their types for the target
+    prop_types: Dict[Node, _OptNodeList] = defaultdict(_OptNodeList)
+    prop_values: Dict[Node, List[Node]] = defaultdict(list)
+    prop_shapes: Dict[Node, _OptNodeList] = defaultdict(_OptNodeList)
+    prop_unspecific: _OptNodeList = _OptNodeList()
+    # TODO: prop_shapes for all properties whose object corresponds to another shape
+    for p, o in templ_graph.predicate_objects(target):
+        if p == RDF.type:
+            continue
+        if str(o).startswith(PARAM) and not str(p).startswith(PARAM):
+            # handle the case where the object is a parameter but the
+            # predicate is not. This will be a property shape with the
+            # predicate as the sh:path.
+
+            # If there's a dependency, use sh:node to refer to that shape
+            param_name = str(o)[len(PARAM) :]
+            dep_templ = templ.dependency_for_parameter(param_name)
+            if dep_templ is not None:
+                # determine which shape list we are inserting into;
+                # if the parameter is optional, put it in the optional list;
+                # else put it in the required list
+                shape_list = prop_shapes[p].required
+                if param_name in templ.optional_args:
+                    shape_list = prop_shapes[p].optional
+
+                # use the template name directly if it is a URI, else put it into the PARAM
+                # namespace to easily convert it to a URI
+                if validate_uri(dep_templ.name):
+                    shape_list.append(URIRef(dep_templ.name))
+                else:
+                    dep_templ_shape_name = PARAM[dep_templ.name]
+                    shape_list.append(dep_templ_shape_name)
+
+            # Otherwise, if "{o} rdf:type {class}" exists within the graph, then
+            # we can associate an sh:class with
+            o_class = templ_graph.value(o, RDF.type)
+            if o_class is not None:
+                # determine which type list we are inserting into;
+                # if the parameter is optional, put it in the optional list;
+                # else put it in the required list
+                type_list = prop_types[p].required
+                if param_name in templ.optional_args:
+                    type_list = prop_types[p].optional
+                type_list.append(o_class)
+            else:
+                unspecific_list = prop_unspecific.required
+                if param_name in templ.optional_args:
+                    unspecific_list = prop_unspecific.optional
+                # if there is no RDF.type and 'o' is not referenced in a dependency,
+                # then ther are no restrictions on its type and we can
+                # add a more permissive PropertyShape
+                unspecific_list.append(p)
+        else:
+            # o is not a PARAM, so use hasValue
+            prop_values[p].append(o)
+
+    return _TemplateIndex(
+        templ,
+        dict(param_types),
+        dict(prop_types),
+        dict(prop_values),
+        dict(prop_shapes),
+        prop_unspecific,
+        target,
+    )
+
+
+def template_to_nodeshape(template: "Template") -> Graph:
+    """
+    Interprets the template body as a SHACL shape and returns the SHACL
+    shape in its own graph. Uses the following rules to perform the transformation:
+    - Generate a SHACL Node Shape
+    - the P:name parameter is considered the 'root' of the shape; only
+      the properties on the P:name-rooted subgraph will be put into the SHACL shape
+    - Add a sh:class property pointing to the object of the 'P:name rdf:type ?class'
+      edge in the template
+    - for each other predicate of P:name in the template, generate a Property Shape:
+      - if there is more than one object for a given predicate, use qualified* SHACL
+        properties, else use the normal varieties
+      - if the object of the predicate is a parameter (in the PARAM namespace), then
+        generate a PropertyShape with sh:class (if an <object> rdf:type <object_type>
+        edge exists in the template) or with sh:node (if the object parameter is
+        referenced by a template dependency)
+      - if the object is a paramater and is optional, make sure the minCount is 0,
+        else default to 1
+      - if the object of the predicate is *not* a parameter, use sh:hasValue
+
+    :return: a graph containing the NodeShape
+    :rtype: rdflib.Graph
+    """
+    # TODO If 'use_all' is True, this will create a shape that incorporates all
+    # Templates by the same name in the same Library.
+    templ = copy(template)
+    shape = _prep_shape_graph()
+
+    idx: _TemplateIndex = _index_properties(templ)
+
+    # TODO: don't add targetClass for now...maybe there is some case where we want it?
+
+    # create the shape
+    shape.add((PARAM[templ.name], RDF.type, SH.NodeShape))
+    shape.add((PARAM[templ.name], SH["class"], idx.target_type))
+    idx.add_to_shape(shape)
+    return shape

--- a/buildingmotif/utils.py
+++ b/buildingmotif/utils.py
@@ -7,6 +7,7 @@ from itertools import chain
 from pathlib import Path
 from typing import TYPE_CHECKING, Dict, List, Optional, Set, Tuple
 
+import rfc3987
 from rdflib import BNode, Graph, Literal, URIRef
 from rdflib.paths import ZeroOrOne
 from rdflib.term import Node
@@ -513,3 +514,11 @@ def skip_uri(uri: URIRef) -> bool:
         if uri.startswith(ns):
             return True
     return False
+
+
+def validate_uri(uri: str):
+    parsed = rfc3987.parse(uri)
+    if not parsed["scheme"]:
+        raise ValueError(
+            f"{uri} does not look like a valid URI, trying to serialize this will break."
+        )

--- a/buildingmotif/utils.py
+++ b/buildingmotif/utils.py
@@ -1,11 +1,7 @@
-import logging
 import secrets
-from collections import defaultdict
-from copy import copy
-from dataclasses import dataclass
 from itertools import chain
 from pathlib import Path
-from typing import TYPE_CHECKING, Dict, List, Optional, Set, Tuple
+from typing import Dict, List, Optional, Set, Tuple
 
 import rfc3987
 from rdflib import BNode, Graph, Literal, URIRef
@@ -13,9 +9,6 @@ from rdflib.paths import ZeroOrOne
 from rdflib.term import Node
 
 from buildingmotif.namespaces import OWL, PARAM, RDF, SH, XSD, bind_prefixes
-
-if TYPE_CHECKING:
-    from buildingmotif.dataclasses import Template
 
 Triple = Tuple[Node, Node, Node]
 _gensym_counter = 0
@@ -251,151 +244,6 @@ def get_template_parts_from_shape(
         deps.append({"template": node, "args": {"name": "name"}})  # tie to root param
 
     return body, deps
-
-
-@dataclass
-class _TemplateIndex:
-    template: "Template"
-    param_types: Dict[Node, List[Node]]
-    prop_types: Dict[Node, List[Node]]
-    prop_values: Dict[Node, List[Node]]
-    prop_shapes: Dict[Node, List[Node]]
-    target: URIRef
-
-    @property
-    def target_type(self):
-        return self.param_types[self.target][0]
-
-
-def _prep_shape_graph() -> Graph:
-    shape = Graph()
-    bind_prefixes(shape)
-    shape.bind("mark", PARAM)
-    return shape
-
-
-def _index_properties(templ: "Template") -> _TemplateIndex:
-    templ_graph = templ.evaluate(
-        {p: PARAM[p] for p in templ.parameters}, {"mark": PARAM}
-    )
-    assert isinstance(templ_graph, Graph)
-
-    # pick a random node to act as the 'target' of the shape
-    target = next(iter(templ_graph.subjects(RDF.type)))
-    print(f"Choosing {target} as the target of the shape")
-    assert isinstance(target, URIRef)
-
-    # store the classes for each parameter
-    param_types: Dict[Node, List[Node]] = defaultdict(list)
-    for (param, ptype) in templ_graph.subject_objects(RDF.type):
-        param_types[param].append(ptype)
-
-    # store the properties and their types for the target
-    prop_types: Dict[Node, List[Node]] = defaultdict(list)
-    prop_values: Dict[Node, List[Node]] = defaultdict(list)
-    prop_shapes: Dict[Node, List[Node]] = defaultdict(list)
-    # TODO: prop_shapes for all properties whose object corresponds to another shape
-    for p, o in templ_graph.predicate_objects(target):
-        if p == RDF.type:
-            continue
-        # maybe_param = str(o).removeprefix(PARAM) Python >=3.9
-        maybe_param = str(o)[len(PARAM) :]
-        if maybe_param in templ.dependency_parameters:
-            dep = templ.dependency_for_parameter(maybe_param)
-            if dep is not None:
-                prop_shapes[p].append(URIRef(dep._name))
-        elif o in param_types:
-            prop_types[p].append(param_types[o][0])
-        elif str(o) not in PARAM:
-            prop_values[p].append(o)
-        elif str(o) in PARAM and o not in param_types:
-            logging.warn(
-                f"{o} is does not have a type and does not seem to be a literal"
-            )
-    return _TemplateIndex(
-        templ,
-        dict(param_types),
-        dict(prop_types),
-        dict(prop_values),
-        dict(prop_shapes),
-        target,
-    )
-
-
-def _add_property_shape(
-    graph: Graph, name: Node, constraint: Node, path: Node, value: Node
-):
-    pshape = BNode()
-    graph.add((name, SH.property, pshape))
-    graph.add((pshape, SH.path, path))
-    graph.add((pshape, constraint, value))
-    graph.add((pshape, SH["minCount"], Literal(1)))
-    graph.add((pshape, SH["maxCount"], Literal(1)))
-
-
-def _add_qualified_property_shape(
-    graph: Graph, name: Node, constraint: Node, path: Node, value: Node
-):
-    pshape = BNode()
-    graph.add((name, SH.property, pshape))
-    graph.add((pshape, SH.path, path))
-    qvc = BNode()
-    graph.add((pshape, SH["qualifiedValueShape"], qvc))
-    graph.add((qvc, constraint, value))
-    graph.add((pshape, SH["qualifiedMinCount"], Literal(1)))
-    graph.add((pshape, SH["qualifiedMaxCount"], Literal(1)))
-
-
-def template_to_shape(template: "Template") -> Graph:
-    """Turn this template into a SHACL shape.
-
-    :param template: template to convert
-    :type template: template
-    :return: graph of template
-    :rtype: Graph
-    """
-    # TODO If 'use_all' is True, this will create a shape that incorporates all
-    # Templates by the same name in the same Library.
-    templ = copy(template)
-    shape = _prep_shape_graph()
-
-    idx = _index_properties(templ)
-
-    shape.add((PARAM[templ.name], SH.targetClass, idx.target_type))
-    # create the shape
-    shape.add((PARAM[templ.name], RDF.type, SH.NodeShape))
-    shape.add((PARAM[templ.name], SH["class"], idx.target_type))
-    for prop, ptypes in idx.prop_types.items():
-        if len(ptypes) == 1:
-            _add_property_shape(shape, PARAM[templ.name], SH["class"], prop, ptypes[0])
-        else:  # more than one ptype
-            for ptype in ptypes:
-                _add_qualified_property_shape(
-                    shape, PARAM[templ.name], SH["class"], prop, ptype
-                )
-    for prop, values in idx.prop_values.items():
-        if len(values) == 1:
-            _add_property_shape(shape, PARAM[templ.name], SH.hasValue, prop, values[0])
-        else:  # more than one ptype
-            for value in values:
-                _add_qualified_property_shape(
-                    shape, PARAM[templ.name], SH.hasValue, prop, value
-                )
-    for prop, shapes in idx.prop_shapes.items():
-        if len(shapes) == 1:
-            _add_property_shape(shape, PARAM[templ.name], SH["node"], prop, shapes[0])
-        else:  # more than one ptype
-            for shp in shapes:
-                _add_qualified_property_shape(
-                    # TODO: fix this?
-                    shape,
-                    PARAM[templ.name],
-                    SH.node,
-                    prop,
-                    PARAM[str(shp)],
-                )
-
-    return shape
 
 
 def new_temporary_graph(more_namespaces: Optional[dict] = None) -> Graph:


### PR DESCRIPTION
This implementation is brought up to date with the current dataclasses and APIs in BuildingMOTIF. Provides a simple algorithm for turning Templates into NodeShapes.

TODO:
- [ ] add test cases for common shape constructs
- [ ] add some documentation in the jupyter book