### PR TITLE
Allow TemplateHandler to handle edge cases in template eval

### DIFF
--- a/buildingmotif/ingresses/template.py
+++ b/buildingmotif/ingresses/template.py
@@ -24,6 +24,8 @@ class TemplateIngress(GraphIngressHandler):
         template: Template,
         mapper: Optional[Callable[[str], str]],
         upstream: RecordIngressHandler,
+        require_optional: bool = False,
+        fill_unused: bool = False,
         inline: bool = False,
     ):
         """
@@ -41,6 +43,14 @@ class TemplateIngress(GraphIngressHandler):
         :param inline: if True, inline the template before evaluating it on
                       each row, defaults to False
         :type inline: bool, optional
+        :param require_optional: if True, require that optional arguments in the
+                      chosen template be provided by the upstream ingress handler,
+                      defaults to False
+        :type require_optional: bool, optional
+        :param fill_unused: if True, mint URIs for any unbound parameters in
+                      the template for each input from the upstream ingress handler,
+                      defaults to False
+        :type fill_unused: bool, optional
         """
         self.mapper = mapper if mapper else lambda x: x
         self.upstream = upstream
@@ -48,6 +58,8 @@ class TemplateIngress(GraphIngressHandler):
             self.template = template.inline_dependencies()
         else:
             self.template = template
+        self.require_optional = require_optional
+        self.fill_unused = fill_unused
 
     def graph(self, ns: Namespace) -> Graph:
         g = Graph()
@@ -60,9 +72,20 @@ class TemplateIngress(GraphIngressHandler):
         assert records is not None
         for rec in records:
             bindings = {self.mapper(k): _get_term(v, ns) for k, v in rec.fields.items()}
-            graph = self.template.evaluate(bindings)
-            assert isinstance(graph, Graph)
-            g += graph
+            graph = self.template.evaluate(
+                bindings, require_optional_args=self.require_optional
+            )
+            # if it is a graph then all expected params were provided and we are done!
+            if isinstance(graph, Graph):
+                g += graph
+                continue
+            # here, we know that the 'graph' variable is actually a Template. If fill_unused
+            # is True, we use 'fill' on the template to generate a new graph
+            if self.fill_unused:
+                _, graph = graph.fill(ns, include_optional=self.require_optional)
+                g += graph
+                continue
+            raise Exception(f"Paramers {graph.parameters} are still unused!")
         return g
 
 


### PR DESCRIPTION
Adds two flags:
- require_optional
- fill_unused

These allow adjustment of how the template ingress handler deal with records that don't necessarily have all the parameters for the chosen template (fill_unused), and how the handler deal with optional parameters in the chosen template (require_optional)

TODOs:
- [ ] add unit tests
- [ ] allow another flag for throwing exception/warning?