### PR TITLE
Create generic serializer deserializer for parsers

### DIFF
--- a/buildingmotif/api/serializers/parser.py
+++ b/buildingmotif/api/serializers/parser.py
@@ -1,0 +1,250 @@
+import warnings
+from functools import lru_cache
+from typing import Any, Literal, Tuple, Type, Union, get_type_hints
+
+from rdflib import URIRef
+from typing_extensions import TypedDict
+
+from buildingmotif.label_parsing.parser import Parser
+from buildingmotif.label_parsing.tokens import Token
+
+ParserDict = TypedDict("ParserDict", {"parser": str, "args": dict})
+
+
+def serialize(parser: Parser) -> ParserDict:
+    """Serialize a parser into a TypedDict.
+
+    :param parser: a parser
+    :type parser: Parser
+    :return: a dict ready for JSON serialization
+    :rtype: ParserDict
+    """
+    parser_dict: ParserDict = {
+        "parser": parser.__class__.__name__,
+        "args": _serialize(parser.__args__),  # type: ignore
+    }
+
+    return parser_dict
+
+
+def _serialize(collection: Union[dict, list, tuple]) -> Union[dict, list]:
+    """Serialize a collection and the contents of that collection into a dict or list
+
+    :param collection: collection to serialize
+    :type collection: Union[dict, list, tuple]
+    :return: serialized collection
+    :rtype: Union[dict, list]
+    """
+
+    def _serialize_item(item):
+        if isinstance(item, URIRef):
+            return str(item)
+        elif isinstance(item, str) or isinstance(item, int) or isinstance(item, float):
+            return item
+        elif item in [None, True, False]:
+            return item
+        elif isinstance(item, Parser):
+            return serialize(item)
+        if isinstance(item, type) and issubclass(item, Token):
+            return {"token": item.__name__}
+        if isinstance(item, Token):
+            return {"token": item.__class__.__name__, "value": str(item.value)}
+        if isinstance(item, list) or isinstance(item, dict) or isinstance(item, tuple):
+            return _serialize(item)
+        warnings.warn(
+            f"Serialization does not exist for object of class {item.__class__} this may cause JSON serialization to fail"
+        )
+        return item
+
+    serialized_collection: Union[dict, list]
+    if isinstance(collection, dict):
+        serialized_collection = {}
+        for key, item in collection.items():
+            serialized_collection[key] = _serialize_item(item)
+    else:
+        serialized_collection = list(map(_serialize_item, collection))
+    return serialized_collection
+
+
+@lru_cache
+def _get_parser_by_name(parser_name: str) -> Type[Parser]:
+    """Get parser class by name of parser.
+
+    :param parser_name: name of parser
+    :type parser_name: str
+    :return: parser class
+    :rtype: Type[Parser]"""
+    parsers = Parser.__subclasses__()
+    for parser in parsers:
+        if parser.__name__ == parser_name:
+            return parser
+    raise NameError(f'Parser of type "{parser_name}" does not exist')
+
+
+@lru_cache
+def _get_token_by_name(token_name: str) -> Type[Token]:
+    """Get token class by name of token
+
+    :param token_name: name of token
+    :type token_name: str
+    :return: token class
+    :rtype: Type[Token]"""
+    tokens = Token.__subclasses__()
+    for token in tokens:
+        if token.__name__ == token_name:
+            return token
+    raise NameError(f'Token of type "{token_name}" does not exist')
+
+
+@lru_cache
+def _get_parser_args_info(
+    parser: Type[Parser],
+) -> Tuple[Union[str, Literal[None]], Union[str, Literal[None]]]:
+    """Get information about the args in a parser's constructor.
+    This has been moved to it's own function to allow for speed improvements by
+    caching results.
+
+    :param parser: parser to inspect
+    :type parser: Type[Parser]
+    :return: variable length positional arguments name, variable length keyword arguments name
+    :rtype: tuple[str, str]"""
+    flags = parser.__init__.__code__.co_flags
+    varargs_flag = (flags & 4) != 0
+    varkeyargs_flag = (flags & 8) != 0
+    var_names = parser.__init__.__code__.co_varnames[1:]
+    varargs_name = None
+    varkeyargs_name = None
+    if varkeyargs_flag:
+        varkeyargs_name = var_names[-1]
+    if varargs_flag:
+        varargs_name = var_names[-1]
+        if varkeyargs_flag:
+            varargs_name = var_names[-2]
+    return (varargs_name, varkeyargs_name)
+
+
+def _construct_class(cls: Type[Parser], args: dict) -> Parser:
+    """Construct class from type and arguments
+
+    :param cls: type of class to construct
+    :type cls: Type
+    :param args: arguments
+    :type args: dict
+    :return: Instance of class
+    :rtype: Any"""
+    varargs_name, varkeyargs_name = _get_parser_args_info(cls)
+    if varkeyargs_name:
+        varkeyargs_value = args[varkeyargs_name]
+        del args[varkeyargs_name]
+        args = {**args, **varkeyargs_value}
+    if varargs_name:
+        if varargs_name in args:
+            varargs_value: list = args[varargs_name]
+            if not isinstance(varargs_value, list):
+                raise TypeError(
+                    "Serialized variadic arguments are not encoded as a list"
+                )
+            del args[varargs_name]
+        return cls(*varargs_value, **args)
+    return cls(**args)
+
+
+def deserialize(parser_dict: Union[ParserDict, dict]) -> Parser:
+    """Deserialize a parser from a TypedDict.
+
+    :param parser_dict: dict containing serialized parser
+    :type parser_dict: ParserDict
+    :return: deserialized parser
+    :rtype: Parser
+    """
+    if not _parser_like(parser_dict):
+        raise TypeError("parser_dict is incorrectly formed")
+    args_dict = dict(
+        (arg, _deserialize(item)) for arg, item in parser_dict["args"].items()
+    )
+    parser = _get_parser_by_name(parser_dict["parser"])
+    return _construct_class(parser, args_dict)
+
+
+@lru_cache
+def _get_token_value_type(token: Type[Token]) -> Type:
+    """Get the type of the token's value argument.
+
+    :param token: token to inspect
+    :type token: Token
+    :return: type of value argument
+    :rtype: Type"""
+    return get_type_hints(token.__init__)["value"]
+
+
+def _deserialize_token(token_dict: dict) -> Union[Token, Type[Token]]:
+    """Deserialize token dict
+
+    :param token_dict: dict containing token
+    :type token_dict: dict
+    :return: deserialized token
+    :rtype: Token"""
+    token = _get_token_by_name(token_dict["token"])
+    if "value" in token_dict:
+        value_type = _get_token_value_type(token)
+        return token(value_type(token_dict["value"]))
+    return token
+
+
+def _deserialize(item: Any) -> Any:
+    """Deserialize an item
+
+    :param item: item to deserialize
+    :type item: Any
+    :return: deserialized item
+    :rtype: Any
+    """
+    if isinstance(item, str) or isinstance(item, int) or isinstance(item, float):
+        return item
+    elif item in [None, True, False]:
+        return item
+    elif isinstance(item, dict):
+        if _parser_like(item):
+            return deserialize(item)
+        elif _token_like(item):
+            return _deserialize_token(item)
+        else:
+            return dict((key, _deserialize(value)) for key, value in item.items())
+    elif isinstance(item, list):
+        return list(map(_deserialize, item))
+    warnings.warn(
+        f"Serialized object contained unexpected type: {item.__class__.__name__}"
+    )
+    return item
+
+
+def _parser_like(item: Union[dict, ParserDict]) -> bool:
+    """Does a dict look like a serialized parser
+
+    :param item: dict to inspect
+    :type item: dict
+    :return: does the dict look like a serialized parser
+    :rtype: bool
+    """
+    if len(item) != 2:
+        return False
+    if "args" not in item:
+        return False
+    if "parser" not in item:
+        return False
+    return True
+
+
+def _token_like(item: dict) -> bool:
+    """Does the dict look like a serialized token
+
+    :param item: dict to inspect
+    :type item: dict
+    :return: does the dict look like a serialized token
+    :rtype: bool
+    """
+    if len(item) > 2:
+        return False
+    if "token" not in item:
+        return False
+    return True

--- a/buildingmotif/label_parsing/parser.py
+++ b/buildingmotif/label_parsing/parser.py
@@ -35,6 +35,26 @@ class ParseResult:
 # the length of the token is used to keep track of how much of the string
 # has been parsed
 class Parser(ABC):
+    __args__: dict
+
+    def __new__(mcls, *args, **kwargs):
+        """When a parser is constructed, save its arguments into a dictionary __args__.
+        This allows parsers to be serialized later without requiring bespoke (de)serialization code
+        for every parser type."""
+        cls = super().__new__(mcls)
+        init_var_names = list(cls.__init__.__code__.co_varnames[1:])
+        rem_var_names = init_var_names
+        for key in kwargs.keys():
+            if key in init_var_names:
+                rem_var_names.remove(key)
+        rem_var_count = len(rem_var_names)
+        cls.__args__ = kwargs
+        if len(args) > rem_var_count:
+            args = [*args[: rem_var_count - 1], args[rem_var_count - 1 :]]
+        cls.__args__.update(dict(zip(init_var_names, args)))
+
+        return cls
+
     @abstractmethod
     def __call__(self, target: str) -> List[TokenResult]:
         pass

--- a/buildingmotif/label_parsing/tokens.py
+++ b/buildingmotif/label_parsing/tokens.py
@@ -1,11 +1,17 @@
+from abc import ABC
 from dataclasses import dataclass
-from typing import Optional, Union
+from typing import Any, Optional, Type, Union
 
 from rdflib import URIRef
 
+
+@dataclass(frozen=True)
+class Token(ABC):
+    value: Any
+
+
 # Token is a union of the different types of tokens
-Token = Union["Identifier", "Constant", "Delimiter", "Null"]
-TokenOrConstructor = Union[Token, type]
+TokenOrConstructor = Union[Token, Type[Token]]
 
 
 def ensure_token(token_or_constructor: TokenOrConstructor, value):
@@ -16,28 +22,28 @@ def ensure_token(token_or_constructor: TokenOrConstructor, value):
 
 
 @dataclass(frozen=True)
-class Identifier:
+class Identifier(Token):
     """An identifier token. Contains a string."""
 
     value: str
 
 
 @dataclass(frozen=True)
-class Constant:
+class Constant(Token):
     """A constant token. Contains a URI, probably some sort of Class"""
 
     value: URIRef
 
 
 @dataclass(frozen=True)
-class Delimiter:
+class Delimiter(Token):
     """A delimiter token."""
 
     value: str
 
 
 @dataclass(frozen=True)
-class Null:
+class Null(Token):
     """A null token."""
 
     value: None = None

--- a/tests/unit/test_combinator_serialization.py
+++ b/tests/unit/test_combinator_serialization.py
@@ -1,0 +1,306 @@
+from buildingmotif.api.serializers.parser import deserialize, serialize
+from buildingmotif.label_parsing.combinators import (
+    COMMON_ABBREVIATIONS,
+    COMMON_EQUIP_ABBREVIATIONS_BRICK,
+    abbreviations,
+    choice,
+    constant,
+    many,
+    maybe,
+    regex,
+    sequence,
+    string,
+    substring_n,
+)
+from buildingmotif.label_parsing.tokens import (
+    Constant,
+    Delimiter,
+    ErrorTokenResult,
+    Identifier,
+    Null,
+    TokenResult,
+)
+from buildingmotif.namespaces import BRICK
+
+
+def test_string_parser():
+    parser = deserialize(serialize(string("abc", Identifier)))
+    # Test that it parses the exact string
+    assert parser("abc") == [
+        TokenResult("abc", Identifier("abc"), 3)
+    ], "Should parse the string"
+    # test that it pulls the substring and leaves the rest
+    assert parser("abcd") == [
+        TokenResult("abc", Identifier("abc"), 3)
+    ], "Should parse the string"
+    # test that it does not parse the string if it is not at the beginning
+    assert parser("0abc") == [
+        ErrorTokenResult
+    ], f"Should not parse the string {parser('0abc')}"
+
+
+def test_substring_n_parser():
+    parser = deserialize(serialize(substring_n(2, Identifier)))
+    # test that it pulls the correct number of characters when there are more than it needs
+    assert parser("abc") == [
+        TokenResult("ab", Identifier("ab"), 2)
+    ], "Should parse the string"
+    # test that it pulls the correct number of characters when there are less than it needs
+    assert parser("a") == [ErrorTokenResult], "Should not parse the string"
+    # test that it pulls the correct number of characters when there are exactly the number it needs
+    assert parser("ab") == [
+        TokenResult("ab", Identifier("ab"), 2)
+    ], "Should parse the string"
+
+
+def test_regex_parser():
+    parser = deserialize(serialize(regex(r"[/\-:_]+", Delimiter)))
+    # test pulling just 1 character
+    assert parser("-abc") == [
+        TokenResult("-", Delimiter("-"), 1)
+    ], "Should parse the string"
+    # test pulling multiple characters
+    assert parser("::_abc") == [
+        TokenResult("::_", Delimiter("::_"), 3)
+    ], "Should parse the string"
+
+
+def test_choice_parser():
+    parser = deserialize(
+        serialize(choice(string("abc", Identifier), string("def", Identifier)))
+    )
+    # test that it parses the first string
+    assert parser("abc") == [
+        TokenResult("abc", Identifier("abc"), 3)
+    ], "Should parse the string"
+    # test that it parses the second string
+    assert parser("def") == [
+        TokenResult("def", Identifier("def"), 3)
+    ], "Should parse the string"
+
+    # test parsing order
+    parser = deserialize(
+        serialize(choice(string("abc", Identifier), string("ab", Identifier)))
+    )
+    # test that it parses the first string
+    assert parser("abc") == [
+        TokenResult("abc", Identifier("abc"), 3)
+    ], "Should parse the string"
+    # test that it parses the second string
+    assert parser("ab") == [
+        TokenResult("ab", Identifier("ab"), 2)
+    ], "Should parse the string"
+
+    # more complex parser
+    parser = deserialize(
+        serialize(
+            choice(
+                string("abc", Identifier),
+                string("def", Identifier),
+                regex(r"[/\-:_]+", Delimiter),
+            )
+        )
+    )
+    # test that it parses the first string
+    assert parser("abc") == [
+        TokenResult("abc", Identifier("abc"), 3)
+    ], "Should parse the string"
+    # test that it parses the second string
+    assert parser("def") == [
+        TokenResult("def", Identifier("def"), 3)
+    ], "Should parse the string"
+    # test the regex matches
+    assert parser("-abc") == [
+        TokenResult("-", Delimiter("-"), 1)
+    ], "Should parse the string"
+    assert parser("doesnotmatch") == [
+        TokenResult(None, Null(), 0)
+    ], "Should not parse the string"
+    assert parser("abdef") == [
+        TokenResult(None, Null(), 0)
+    ], "Should not parse the string"
+
+
+def test_constant_parser():
+    parser = deserialize(serialize(constant(Constant(BRICK.Air_Handling_Unit))))
+    # test that the constant is emitted
+    assert parser("abc") == [
+        TokenResult(None, Constant(BRICK.Air_Handling_Unit), 0)
+    ], "Should parse the string"
+    assert parser("") == [
+        TokenResult(None, Constant(BRICK.Air_Handling_Unit), 0)
+    ], "Should parse the string"
+
+
+def test_abbreviations():
+    parser = deserialize(serialize(abbreviations(COMMON_EQUIP_ABBREVIATIONS_BRICK)))
+    # test that the constant is emitted
+    assert parser("AHU") == [
+        TokenResult("AHU", Constant(BRICK.Air_Handling_Unit), 3)
+    ], "Should parse the string"
+    # test that only the matching characters are consumed
+    assert parser("AHU1") == [
+        TokenResult("AHU", Constant(BRICK.Air_Handling_Unit), 3)
+    ], "Should parse the string"
+    assert parser("BADABBREVIATION") == [
+        TokenResult(None, Null(), 0)
+    ], "Should not parse the string"
+
+
+def test_sequence():
+    parser = deserialize(
+        serialize(sequence([string("abc", Identifier), string("def", Identifier)]))
+    )
+    # test that it parses the whole sequence
+    assert parser("abcdef") == [
+        TokenResult("abc", Identifier("abc"), 3),
+        TokenResult("def", Identifier("def"), 3),
+    ], "Should parse the string"
+
+    # test multiple kinds of parsers inside
+    parser = deserialize(
+        serialize(
+            sequence(
+                [
+                    abbreviations(COMMON_EQUIP_ABBREVIATIONS_BRICK),
+                    regex(r"[/\-:_]+", Delimiter),
+                    regex(r"[0-9]+", Identifier),
+                ]
+            )
+        )
+    )
+
+    # test that only the matching characters are consumed
+    assert parser("AHU-1") == [
+        TokenResult("AHU", Constant(BRICK.Air_Handling_Unit), 3),
+        TokenResult("-", Delimiter("-"), 1),
+        TokenResult("1", Identifier("1"), 1),
+    ], "Should parse the string"
+    assert parser("AHU1-") == [
+        TokenResult("AHU", Constant(BRICK.Air_Handling_Unit), 3),
+        ErrorTokenResult,
+    ], "Should not parse all of the string"
+
+
+def test_many():
+    delim = regex(r"[_\-:/]+", Delimiter)
+    type_ident_delim = deserialize(
+        serialize(
+            sequence(
+                [
+                    COMMON_ABBREVIATIONS,
+                    regex(r"\d+", Identifier),
+                    delim,
+                ]
+            )
+        )
+    )
+    parser = many(type_ident_delim)
+
+    # test that it parses the whole sequence
+    assert parser("AHU1") == [
+        TokenResult("AHU", Constant(BRICK.Air_Handling_Unit), 3),
+        TokenResult("1", Identifier("1"), 1),
+        ErrorTokenResult,
+    ]
+    # no delimiter at the end, so it should not parse the whole thing
+    assert parser("AHU1/SP2") == [
+        TokenResult("AHU", Constant(BRICK.Air_Handling_Unit), 3),
+        TokenResult("1", Identifier("1"), 1),
+        TokenResult("/", Delimiter("/"), 1),
+        TokenResult("SP", Constant(BRICK.Setpoint), 2),
+        TokenResult("2", Identifier("2"), 1),
+        ErrorTokenResult,
+    ]
+    # test that it parses multiple sequences
+    assert parser("AHU1/SP2/") == [
+        TokenResult("AHU", Constant(BRICK.Air_Handling_Unit), 3),
+        TokenResult("1", Identifier("1"), 1),
+        TokenResult("/", Delimiter("/"), 1),
+        TokenResult("SP", Constant(BRICK.Setpoint), 2),
+        TokenResult("2", Identifier("2"), 1),
+        TokenResult("/", Delimiter("/"), 1),
+    ]
+
+
+def test_maybe():
+    parser = deserialize(
+        serialize(
+            sequence(
+                [
+                    maybe(string("abc", Identifier)),
+                    string("def", Identifier),
+                ]
+            )
+        )
+    )
+    # test that it parses the whole sequence
+    assert parser("abcdef") == [
+        TokenResult("abc", Identifier("abc"), 3),
+        TokenResult("def", Identifier("def"), 3),
+    ], "Should parse the string"
+    assert parser("def") == [
+        TokenResult(None, Null(), 0),
+        TokenResult("def", Identifier("def"), 3),
+    ], "Should parse the string"
+
+    # test sequence inside maybe
+    parser = deserialize(
+        serialize(
+            sequence(
+                [
+                    maybe(
+                        sequence(
+                            [
+                                string("abc", Identifier),
+                                string("def", Identifier),
+                            ]
+                        )
+                    ),
+                    string("ghi", Identifier),
+                ]
+            )
+        )
+    )
+    assert parser("ghi") == [
+        TokenResult(None, Null(), 0),
+        TokenResult("ghi", Identifier("ghi"), 3),
+    ], "Should parse the string"
+
+    assert parser("abcdefghi") == [
+        TokenResult("abc", Identifier("abc"), 3),
+        TokenResult("def", Identifier("def"), 3),
+        TokenResult("ghi", Identifier("ghi"), 3),
+    ], "Should parse the string"
+
+    # test maybe inside sequence
+    parser = deserialize(
+        serialize(
+            sequence(
+                [
+                    string("abc", Identifier),
+                    maybe(
+                        sequence(
+                            [
+                                string("def", Identifier),
+                                string("ghi", Identifier),
+                            ]
+                        )
+                    ),
+                    string("jkl", Identifier),
+                ]
+            )
+        )
+    )
+    assert parser("abcjkl") == [
+        TokenResult("abc", Identifier("abc"), 3),
+        TokenResult(None, Null(), 0),
+        TokenResult("jkl", Identifier("jkl"), 3),
+    ], "Should parse the string"
+
+    assert parser("abcdefghijkl") == [
+        TokenResult("abc", Identifier("abc"), 3),
+        TokenResult("def", Identifier("def"), 3),
+        TokenResult("ghi", Identifier("ghi"), 3),
+        TokenResult("jkl", Identifier("jkl"), 3),
+    ], "Should parse the string"


### PR DESCRIPTION
Create `serializer` and `deserialize` functions for Parsers.

Changes in serialized structure:
- `name` becomes `parser`
- tokens are now a dict with key `token` and optional token `value`. This allows for a instanced or constructor token to be created.

Some performance profiling was done:
- deserialization of common abbreviations takes 0.2ms on my machine.
- tests (copy of existing parser tests with `deserialize(serialize(...))` added as a wrapper) complete in less than .1 seconds
With these numbers I think this is fast enough to allow us to use this generic parser version.