### PR TITLE
Strip param inlining

### DIFF
--- a/buildingmotif/dataclasses/template.py
+++ b/buildingmotif/dataclasses/template.py
@@ -19,6 +19,7 @@ from buildingmotif.namespaces import bind_prefixes
 from buildingmotif.template_matcher import Mapping, TemplateMatcher
 from buildingmotif.utils import (
     PARAM,
+    _strip_param,
     combine_graphs,
     copy_graph,
     remove_triples_with_node,
@@ -280,17 +281,18 @@ class Template:
             # replace dependency parameters with the names they inherit
             # through the provided bindings
             rename_params: Dict[str, str] = {
-                ours: theirs for ours, theirs in dep.args.items()
+                ours: _strip_param(theirs) for ours, theirs in dep.args.items()
             }
             # replace all parameters *not* mentioned in the args by prefixing
             # them with the 'name' parameter binding; this is guaranteed
             # to exist
-            name_prefix = dep.args.get("name")
+            name_prefix = _strip_param(dep.args["name"])
             # for each parameter in the dependency...
             for param in deptempl.parameters:
                 # if it does *not* have a mapping in the dependency, then
                 # prefix the parameter with the value of the 'name' binding
                 # to scope it properly
+                param = _strip_param(param)
                 if param not in dep.args and param != "name":
                     rename_params[param] = f"{name_prefix}-{param}"
 

--- a/buildingmotif/utils.py
+++ b/buildingmotif/utils.py
@@ -5,7 +5,7 @@ from copy import copy
 from dataclasses import dataclass
 from itertools import chain
 from pathlib import Path
-from typing import TYPE_CHECKING, Dict, List, Optional, Set, Tuple
+from typing import TYPE_CHECKING, Dict, List, Optional, Set, Tuple, Union
 
 import pyshacl  # type: ignore
 from rdflib import BNode, Graph, Literal, URIRef
@@ -20,6 +20,16 @@ if TYPE_CHECKING:
 
 Triple = Tuple[Node, Node, Node]
 _gensym_counter = 0
+
+
+def _strip_param(param: Union[Node, str]) -> str:
+    """
+    Strips all PARAM namespaces from the input parameter
+    """
+    param = str(param)
+    while param.startswith(PARAM):
+        param = param[len(PARAM) :]
+    return param
 
 
 def _gensym(prefix: str = "p") -> URIRef:

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -7,6 +7,7 @@ from buildingmotif.namespaces import BRICK, SH, XSD, A
 from buildingmotif.utils import (
     PARAM,
     _param_name,
+    _strip_param,
     get_parameters,
     get_template_parts_from_shape,
     graph_hash,
@@ -357,3 +358,23 @@ def test_hash(bm: BuildingMOTIF):
 
     after_hash = graph_hash(model.graph)
     assert before_hash == after_hash, "Graph with same state resulted in different hash"
+
+
+def test_strip_param():
+    # if value is 'None', key should remain unchanged
+    inputs = {
+        "p123": None,
+        "urn:___param___#123": "123",
+        "urn:___param___/123": None,
+        "urn:___param___#urn___param___#123": "123",
+    }
+    for input_val, expected in inputs.items():
+        output = _strip_param(input_val)
+        if expected is None:
+            assert (
+                input_val == output
+            ), f"Input {input_val} should remain unchanged but was {output}"
+        else:
+            assert (
+                expected == output
+            ), f"Input {input_val} should be {expected} but was {output}"

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -366,7 +366,7 @@ def test_strip_param():
         "p123": None,
         "urn:___param___#123": "123",
         "urn:___param___/123": None,
-        "urn:___param___#urn___param___#123": "123",
+        "urn:___param___#urn:___param___#123": "123",
     }
     for input_val, expected in inputs.items():
         output = _strip_param(input_val)


### PR DESCRIPTION
Required for https://github.com/NREL/BuildingMOTIF/pull/309 . When we recursively inline parameters, the names were not normalized and so subsequent evaluation of inlined templates did not work properly.