### PR TITLE
Fix autogeneration of templates

### DIFF
--- a/buildingmotif/utils.py
+++ b/buildingmotif/utils.py
@@ -12,11 +12,12 @@ from rdflib import BNode, Graph, Literal, URIRef
 from rdflib.compare import _TripleCanonicalizer
 from rdflib.paths import ZeroOrOne
 from rdflib.term import Node
+from sqlalchemy.exc import NoResultFound
 
 from buildingmotif.namespaces import OWL, PARAM, RDF, SH, XSD, bind_prefixes
 
 if TYPE_CHECKING:
-    from buildingmotif.dataclasses import Template
+    from buildingmotif.dataclasses import Library, Template
 
 Triple = Tuple[Node, Node, Node]
 _gensym_counter = 0
@@ -47,6 +48,25 @@ def _param_name(param: URIRef) -> str:
     """
     assert param.startswith(PARAM)
     return param[len(PARAM) :]
+
+
+def _guarantee_unique_template_name(library: "Library", name: str) -> str:
+    """
+    Ensure that the template name is unique in the library by appending an increasing
+    number. This is only called when we are generating templates from GraphDiffs and
+    the names are local to the Library. The Library is intended to be ephemeral so these
+    names will not be around for long.
+    """
+    idx = 1
+    original_name = name
+    try:
+        while library.get_template_by_name(name):
+            name = f"{original_name}_{idx}"
+            idx += 1
+    except NoResultFound:
+        # this means that the template does not exist and we can use the original name
+        pass
+    return name
 
 
 def copy_graph(g: Graph, preserve_blank_nodes: bool = True) -> Graph:

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -2,10 +2,11 @@ import pytest
 from rdflib import Graph, Literal, Namespace, URIRef
 
 from buildingmotif import BuildingMOTIF
-from buildingmotif.dataclasses import Model, ShapeCollection
+from buildingmotif.dataclasses import Library, Model, ShapeCollection
 from buildingmotif.namespaces import BRICK, SH, XSD, A
 from buildingmotif.utils import (
     PARAM,
+    _guarantee_unique_template_name,
     _param_name,
     _strip_param,
     get_parameters,
@@ -378,3 +379,22 @@ def test_strip_param():
             assert (
                 expected == output
             ), f"Input {input_val} should be {expected} but was {output}"
+
+
+def test_guarantee_unique_template_name(bm):
+    # make new library
+    lib = Library.create("test")
+    # add a template
+    lib.create_template("test_template", None)
+
+    # create a new template with the same name
+    name = _guarantee_unique_template_name(lib, "test_template")
+    assert name == "test_template_1"
+
+    lib.create_template(name, None)
+
+    # create a new template with the same name
+    name = _guarantee_unique_template_name(lib, "test_template")
+    assert name == "test_template_2"
+
+    lib.create_template(name, None)


### PR DESCRIPTION
When generating templates in the validation code, it may be the case that we generate templates with the same name. This patches that behavior *specifically* for the validation code by adding an incrementing integer when the GraphDiff implementations attempt to add a template to a library